### PR TITLE
Better FocusFire Behavior

### DIFF
--- a/bin/BotConfig.txt
+++ b/bin/BotConfig.txt
@@ -11,7 +11,7 @@
         "BotRace"                   : "Terran",
         "EnemyDifficulty"           : 1,
         "EnemyRace"                 : "Zerg",
-        "MapFile"                   : "DefeatZerglingsAndBanelings.SC2Map",
+        "MapFile"                   : "DefeatRoaches.SC2Map",
         "StepSize"                  : 1
     },
         

--- a/src/DonePullBackTransition.cpp
+++ b/src/DonePullBackTransition.cpp
@@ -9,11 +9,11 @@ DonePullBackTransition::DonePullBackTransition(const sc2::Unit * unit, sc2::Poin
     m_position = position;
 }
 
-bool DonePullBackTransition::isValid(const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*)
+bool DonePullBackTransition::isValid(const sc2::Unit * target, const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*)
 {
     bool done(false);
     done = m_position == m_unit->pos;
-    if (Util::Dist(m_position, m_unit->pos) < 0.1f)
+    if (Util::Dist(m_position, m_unit->pos) < 1.5f)
         return true;
     else
         return false;

--- a/src/DonePullBackTransition.cpp
+++ b/src/DonePullBackTransition.cpp
@@ -9,7 +9,7 @@ DonePullBackTransition::DonePullBackTransition(const sc2::Unit * unit, sc2::Poin
     m_position = position;
 }
 
-bool DonePullBackTransition::isValid(std::unordered_map<sc2::Tag, float> *, CCBot*)
+bool DonePullBackTransition::isValid(const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*)
 {
     bool done(false);
     done = m_position == m_unit->pos;
@@ -18,6 +18,7 @@ bool DonePullBackTransition::isValid(std::unordered_map<sc2::Tag, float> *, CCBo
     else
         return false;
 }
+
 FocusFireFSMState* DonePullBackTransition::getNextState()
 {
     return m_nextState;

--- a/src/DonePullBackTransition.h
+++ b/src/DonePullBackTransition.h
@@ -10,7 +10,7 @@ private:
     sc2::Point2D m_position;
 public:
     DonePullBackTransition(const sc2::Unit * rangedUnit, sc2::Point2D position, FocusFireFSMState* nextState);
-    bool isValid(const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*);
+    bool isValid(const sc2::Unit * target, const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*);
     FocusFireFSMState* getNextState();
     void onTransition();
 };

--- a/src/DonePullBackTransition.h
+++ b/src/DonePullBackTransition.h
@@ -10,7 +10,7 @@ private:
     sc2::Point2D m_position;
 public:
     DonePullBackTransition(const sc2::Unit * rangedUnit, sc2::Point2D position, FocusFireFSMState* nextState);
-    bool isValid(std::unordered_map<sc2::Tag, float> *, CCBot*);
+    bool isValid(const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*);
     FocusFireFSMState* getNextState();
     void onTransition();
 };

--- a/src/FireClosestFSMState.cpp
+++ b/src/FireClosestFSMState.cpp
@@ -3,16 +3,15 @@
 #include "ShouldPullBackTransition.h"
 #include "CCBot.h"
 
-FireClosestFSMState::FireClosestFSMState(const sc2::Unit * unit, const sc2::Unit * target)
+FireClosestFSMState::FireClosestFSMState(const sc2::Unit * unit)
 {
     m_unit = unit;
-    m_target = target;
 }
 
 void FireClosestFSMState::onEnter(const std::vector<const sc2::Unit*> *, CCBot*)
 {
-    FocusFireFSMState* pullBack = new PullBackFSMState(m_unit, m_target);
-    FocusFireFSMTransition* shouldPull = new ShouldPullBackTransition(m_unit, m_target, pullBack);
+    FocusFireFSMState* pullBack = new PullBackFSMState(m_unit);
+    FocusFireFSMTransition* shouldPull = new ShouldPullBackTransition(m_unit, pullBack);
     transitions = { shouldPull };
 }
 void FireClosestFSMState::onExit() {}
@@ -22,6 +21,5 @@ std::vector<FocusFireFSMTransition*> FireClosestFSMState::getTransitions()
 }
 void FireClosestFSMState::onUpdate(const sc2::Unit * target, CCBot* bot) 
 {
-    m_target = target;
-    bot->Actions()->UnitCommand(m_unit, sc2::ABILITY_ID::ATTACK_ATTACK, m_target);
+    bot->Actions()->UnitCommand(m_unit, sc2::ABILITY_ID::ATTACK_ATTACK, target);
 }

--- a/src/FireClosestFSMState.h
+++ b/src/FireClosestFSMState.h
@@ -6,10 +6,9 @@ class FireClosestFSMState : public FocusFireFSMState
 {
 private:
     const sc2::Unit * m_unit;
-    const sc2::Unit * m_target;
     std::vector<FocusFireFSMTransition*> transitions;
 public:
-    FireClosestFSMState(const sc2::Unit * unit, const sc2::Unit * target);
+    FireClosestFSMState(const sc2::Unit * unit);
     void onEnter(const std::vector<const sc2::Unit*> *, CCBot*);
     void onUpdate(const sc2::Unit * target, CCBot*);
     void onExit();

--- a/src/FocusFireFSM.h
+++ b/src/FocusFireFSM.h
@@ -14,5 +14,5 @@ class FocusFireFSMTransition : public FSMTransition
 {
 public:
     virtual FocusFireFSMState* getNextState() { return nullptr; };
-    virtual bool isValid(std::unordered_map<sc2::Tag, float> *, CCBot*) { return false; };
+    virtual bool isValid(const std::vector<const sc2::Unit*> *units, std::unordered_map<sc2::Tag, float> *, CCBot*) { return false; };
 };

--- a/src/FocusFireFSM.h
+++ b/src/FocusFireFSM.h
@@ -14,5 +14,5 @@ class FocusFireFSMTransition : public FSMTransition
 {
 public:
     virtual FocusFireFSMState* getNextState() { return nullptr; };
-    virtual bool isValid(const std::vector<const sc2::Unit*> *units, std::unordered_map<sc2::Tag, float> *, CCBot*) { return false; };
+    virtual bool isValid(const sc2::Unit * target, const std::vector<const sc2::Unit*> *units, std::unordered_map<sc2::Tag, float> *, CCBot*) { return false; };
 };

--- a/src/FocusFireFiniteStateMachine.cpp
+++ b/src/FocusFireFiniteStateMachine.cpp
@@ -12,11 +12,11 @@ FocusFireFiniteStateMachine::FocusFireFiniteStateMachine(const sc2::Unit * unit,
     activeState->onEnter(targets, bot);
 }
 
-void FocusFireFiniteStateMachine::update(const sc2::Unit * target, const std::vector<const sc2::Unit*> * targets, std::unordered_map<sc2::Tag, float> * unitHealth, CCBot* bot)
+void FocusFireFiniteStateMachine::update(const sc2::Unit * target, const std::vector<const sc2::Unit*> * targets, const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> * unitHealth, CCBot* bot)
 {
     for (auto transition : activeState->getTransitions())
     {
-        if (transition->isValid(unitHealth, bot))
+        if (transition->isValid(units, unitHealth, bot))
         {
             activeState->onExit();
             activeState = transition->getNextState();

--- a/src/FocusFireFiniteStateMachine.cpp
+++ b/src/FocusFireFiniteStateMachine.cpp
@@ -5,8 +5,8 @@
 FocusFireFiniteStateMachine::FocusFireFiniteStateMachine() {};
 FocusFireFiniteStateMachine::FocusFireFiniteStateMachine(const sc2::Unit * unit, const sc2::Unit * target, const std::vector<const sc2::Unit*> * targets, CCBot* bot)
 {
-    FocusFireFSMState* fireClosest = new FireClosestFSMState(unit, target);
-    FocusFireFSMState* pullBack = new PullBackFSMState(unit, target);
+    FocusFireFSMState* fireClosest = new FireClosestFSMState(unit);
+    FocusFireFSMState* pullBack = new PullBackFSMState(unit);
     initialState = fireClosest;
     activeState = initialState;
     activeState->onEnter(targets, bot);
@@ -16,7 +16,7 @@ void FocusFireFiniteStateMachine::update(const sc2::Unit * target, const std::ve
 {
     for (auto transition : activeState->getTransitions())
     {
-        if (transition->isValid(units, unitHealth, bot))
+        if (transition->isValid(target, units, unitHealth, bot))
         {
             activeState->onExit();
             activeState = transition->getNextState();

--- a/src/FocusFireFiniteStateMachine.h
+++ b/src/FocusFireFiniteStateMachine.h
@@ -9,6 +9,6 @@ private:
     FocusFireFSMState* activeState;
 public:
     FocusFireFiniteStateMachine();
-    FocusFireFiniteStateMachine(const sc2::Unit *, const sc2::Unit * target, const std::vector<const sc2::Unit*> *, CCBot*);
-    void update(const sc2::Unit * target, const std::vector<const sc2::Unit*> * targets, std::unordered_map<sc2::Tag, float> *unitHealth, CCBot* bot);
+    FocusFireFiniteStateMachine(const sc2::Unit *, const sc2::Unit * target, const std::vector<const sc2::Unit*> * targets, CCBot*);
+    void update(const sc2::Unit * target, const std::vector<const sc2::Unit*> * targets, const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *unitHealth, CCBot* bot);
 };

--- a/src/Micro.cpp
+++ b/src/Micro.cpp
@@ -57,7 +57,7 @@ void Micro::SmartKiteTarget(const sc2::Unit * rangedUnit, const sc2::Unit * targ
     state.insert_or_assign(rangedUnit->tag, stateMachine);
 }
 
-void Micro::SmartFocusFire(const sc2::Unit * rangedUnit, const sc2::Unit * target, const std::vector<const sc2::Unit *> * targets, CCBot & bot, std::unordered_map<sc2::Tag, FocusFireFiniteStateMachine*> &state, std::unordered_map<sc2::Tag, float> &unitHealth)
+void Micro::SmartFocusFire(const sc2::Unit * rangedUnit, const sc2::Unit * target, const std::vector<const sc2::Unit *> * targets, CCBot & bot, std::unordered_map<sc2::Tag, FocusFireFiniteStateMachine*> &state, const std::vector<const sc2::Unit *> * units, std::unordered_map<sc2::Tag, float> &unitHealth)
 {
     BOT_ASSERT(rangedUnit != nullptr, "RangedUnit is null");
     BOT_ASSERT(target != nullptr, "Target is null");
@@ -67,7 +67,7 @@ void Micro::SmartFocusFire(const sc2::Unit * rangedUnit, const sc2::Unit * targe
         stateMachine = new FocusFireFiniteStateMachine(rangedUnit, target, targets, &bot);
     else stateMachine = state[rangedUnit->tag];
     
-    stateMachine->update(target, targets, &unitHealth, &bot);
+    stateMachine->update(target, targets, units, &unitHealth, &bot);
     state.insert_or_assign(rangedUnit->tag, stateMachine);
 }
 

--- a/src/Micro.h
+++ b/src/Micro.h
@@ -18,9 +18,10 @@ namespace Micro
 	void SmartFocusFire     (
         const sc2::Unit * rangedUnit,
         const sc2::Unit * target, 
-        const std::vector<const sc2::Unit *> *, 
+        const std::vector<const sc2::Unit *> * targets, 
         CCBot & bot, 
         std::unordered_map<sc2::Tag, FocusFireFiniteStateMachine*> &states,
+        const std::vector<const sc2::Unit *> * units,
         std::unordered_map<sc2::Tag, float> &unitHealth
     );
     void SmartBuild         (const sc2::Unit * builder,   const sc2::UnitTypeID & buildingType, sc2::Point2D pos, CCBot & bot);

--- a/src/MicroManager.h
+++ b/src/MicroManager.h
@@ -45,5 +45,5 @@ public:
     std::unordered_map<sc2::Tag, FocusFireFiniteStateMachine*> m_focusFireStates;
     std::unordered_map<sc2::Tag, KitingFiniteStateMachine*> m_kittingStates;
     std::unordered_map<sc2::Tag, float> m_unitHealth;
-
+    bool m_rallied;
 };

--- a/src/PullBackFSMState.cpp
+++ b/src/PullBackFSMState.cpp
@@ -22,9 +22,8 @@ void PullBackFSMState::onEnter(const std::vector<const sc2::Unit*> * targets, CC
         if (Util::Dist(target->pos, m_unit->pos) < Util::Dist(closestTarget, m_unit->pos))
             closestTarget = target->pos;
 
-    sc2::Point2D direction = m_unit->pos - ((closestTarget + Util::CalcCenter(*targets)) / 2);
-    float norm = sqrt(pow(direction.x, 2) + pow(direction.y, 2));
-    direction /= norm; // normalized
+    sc2::Point2D direction = m_unit->pos - closestTarget;// ((closestTarget + Util::CalcCenter(*targets)) / 2);
+    Util::Normalize(direction);
     m_position = (direction * (targetRange + 2.f)) + closestTarget;
 
     FocusFireFSMState* fireClosest = new FireClosestFSMState(m_unit, m_target);

--- a/src/PullBackFSMState.cpp
+++ b/src/PullBackFSMState.cpp
@@ -5,36 +5,45 @@
 #include "Util.h"
 #include <algorithm>
 
-PullBackFSMState::PullBackFSMState(const sc2::Unit * unit, const sc2::Unit * target)
+PullBackFSMState::PullBackFSMState(const sc2::Unit * unit)
 {
     m_unit = unit;
-    m_target = target;
 }
 
 void PullBackFSMState::onEnter(const std::vector<const sc2::Unit*> * targets, CCBot* bot)
 {
-    auto targetWeapons = bot->Observation()->GetUnitTypeData()[m_target->unit_type].weapons;
-    float targetRange = 0.f;
-    for (auto weapon : targetWeapons) targetRange = std::max(weapon.range, targetRange);
-
-    sc2::Point2D closestTarget = targets->at(0)->pos;
+    const sc2::Unit* closestTarget = targets->at(0);
+    float minDist = Util::Dist(closestTarget->pos, m_unit->pos);
     for (auto target : *targets)
-        if (Util::Dist(target->pos, m_unit->pos) < Util::Dist(closestTarget, m_unit->pos))
-            closestTarget = target->pos;
+    {
+        float targetDist = Util::Dist(target->pos, m_unit->pos);
+        if (targetDist < minDist)
+        {
+            closestTarget = target;
+            minDist = targetDist;
+        }
+    }
 
-    sc2::Point2D direction = m_unit->pos - closestTarget;// ((closestTarget + Util::CalcCenter(*targets)) / 2);
+    float targetRange = Util::GetAttackRangeForTarget(closestTarget, m_unit, *bot);
+
+    sc2::Point2D direction = m_unit->pos - closestTarget->pos;
     Util::Normalize(direction);
-    m_position = (direction * (targetRange + 2.f)) + closestTarget;
+    m_position = (direction * (targetRange + 1.5f)) + closestTarget->pos;
+    if (!bot->Map().isWalkable(m_position))
+        m_position = m_unit->pos;
 
-    FocusFireFSMState* fireClosest = new FireClosestFSMState(m_unit, m_target);
+    FocusFireFSMState* fireClosest = new FireClosestFSMState(m_unit);
     FocusFireFSMTransition* donePull = new DonePullBackTransition(m_unit, m_position, fireClosest);
     this->transitions = { donePull };
 }
+
 void PullBackFSMState::onExit() {}
+
 std::vector<FocusFireFSMTransition*> PullBackFSMState::getTransitions()
 {
     return transitions;
 }
+
 void PullBackFSMState::onUpdate(const sc2::Unit * target, CCBot* bot)
 {
     bot->Actions()->UnitCommand(m_unit, sc2::ABILITY_ID::MOVE, m_position);

--- a/src/PullBackFSMState.h
+++ b/src/PullBackFSMState.h
@@ -5,11 +5,10 @@ class PullBackFSMState : public FocusFireFSMState
 {
 private:
     const sc2::Unit * m_unit;
-    const sc2::Unit * m_target;
     sc2::Point2D m_position;
     std::vector<FocusFireFSMTransition*> transitions;
 public:
-    PullBackFSMState(const sc2::Unit * unit, const sc2::Unit * target);
+    PullBackFSMState(const sc2::Unit * unit);
     void onEnter(const std::vector<const sc2::Unit*> *, CCBot*);
     void onUpdate(const sc2::Unit * target, CCBot*);
     void onExit();

--- a/src/RangedManager.cpp
+++ b/src/RangedManager.cpp
@@ -35,7 +35,7 @@ void RangedManager::assignTargets(const std::vector<const sc2::Unit *> & targets
     {
         if (!rangedUnitTargets.empty())
         {
-            sc2::Point2D targetCenterPoint = Util::CalcCenter(rangedUnitTargets);
+            /*sc2::Point2D targetCenterPoint = Util::CalcCenter(rangedUnitTargets);
             sc2::Point2D unitCenterPoint = Util::CalcCenter(rangedUnits);
             //reset the rallied state if units are too far from enemy units
             if (m_rallied)
@@ -85,7 +85,7 @@ void RangedManager::assignTargets(const std::vector<const sc2::Unit *> & targets
                 if (!allUnitsPlaced)
                     return;
                 m_rallied = true;
-            }
+            }*/
 
             // for each rangedUnit
             for (auto rangedUnit : rangedUnits)

--- a/src/ShouldPullBackTransition.cpp
+++ b/src/ShouldPullBackTransition.cpp
@@ -9,20 +9,44 @@ ShouldPullBackTransition::ShouldPullBackTransition(const sc2::Unit * unit, const
     m_nextState = nextState;
 }
 
-bool ShouldPullBackTransition::isValid(std::unordered_map<sc2::Tag, float> * unitHealth, CCBot* bot)
+bool ShouldPullBackTransition::isValid(const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> * unitHealth, CCBot* bot)
 {
+    //update health in the health map
+    if (unitHealth->find(m_unit->tag) == unitHealth->end())
+        unitHealth->insert_or_assign(m_unit->tag, m_unit->health);
+    float previousHealth = unitHealth->at(m_unit->tag);
+    unitHealth->insert_or_assign(m_unit->tag, m_unit->health);
+
     auto targetWeapons = bot->Observation()->GetUnitTypeData()[m_target->unit_type].weapons;
     float damage = 0.f;
     for (auto weapon : targetWeapons)
         if (weapon.damage_ > damage) damage = weapon.damage_;
 
-    if (unitHealth->find(m_unit->tag) == unitHealth->end())
-        unitHealth->insert_or_assign(m_unit->tag, m_unit->health);
-    float previousHealth = unitHealth->at(m_unit->tag);
+    //condition 1: if this unit would get killed by 1 attack from the target and there is no other unit closer to the target, this unit should back
+    if (m_unit->health <= damage)
+    {
+        float dist = Util::Dist(m_unit->pos, m_target->pos);
+        if (dist <= Util::GetAttackRangeForTarget(m_unit, m_target, *bot))
+        {
+            bool otherUnitCloser = false;
+            for (const sc2::Unit* unit : *units)
+            {
+                if (unit != m_unit && Util::Dist(unit->pos, m_target->pos) < dist)
+                {
+                    //no need to pull back, since another unit is closer to target
+                    otherUnitCloser = true;
+                    break;
+                }
+            }
+            if (!otherUnitCloser)
+            {
+                return true;
+            }
+        }
+    }
 
-    bool shouldBack = previousHealth > m_unit->health && m_unit->health <= (damage * 2);
-    unitHealth->insert_or_assign(m_unit->tag, m_unit->health);
-    return shouldBack;
+    //condition 2: if the unit just got hit and it would die in 2 attacks from the target, it should back
+    return previousHealth > m_unit->health && m_unit->health <= (damage * 2);
 }
 FocusFireFSMState* ShouldPullBackTransition::getNextState()
 {

--- a/src/ShouldPullBackTransition.cpp
+++ b/src/ShouldPullBackTransition.cpp
@@ -19,6 +19,20 @@ bool ShouldPullBackTransition::isValid(const sc2::Unit * target, const std::vect
     float damage = Util::GetAttackDamageForTarget(target, m_unit, *bot);
     float unitdamage = Util::GetAttackDamageForTarget(m_unit, target, *bot);
 
+    bool healthierUnit = false;
+    for (const sc2::Unit* unit : *units)
+    {
+        if (unit != m_unit && unit->health > m_unit->health)
+        {
+            healthierUnit = true;
+            break;
+        }
+    }
+
+    //it is useless to back if none of our units can soak up the damage
+    if (!healthierUnit)
+        return false;
+
     //condition 1: if this unit would get killed by 1 attack from the target and there is no other unit closer to the target, this unit should back
     if (m_unit->health <= damage)
     {
@@ -28,7 +42,8 @@ bool ShouldPullBackTransition::isValid(const sc2::Unit * target, const std::vect
             bool otherUnitCloser = false;
             for (const sc2::Unit* unit : *units)
             {
-                if (unit != m_unit && Util::Dist(unit->pos, target->pos) < dist)
+                //0.2f is a buffer, because an enemy unit might not target the closest unit when both are almost at the same distance
+                if (unit != m_unit && Util::Dist(unit->pos, target->pos) + 0.2f < dist)
                 {
                     //no need to pull back, since another unit is closer to target
                     otherUnitCloser = true;

--- a/src/ShouldPullBackTransition.h
+++ b/src/ShouldPullBackTransition.h
@@ -7,11 +7,10 @@ class ShouldPullBackTransition : public FocusFireFSMTransition
 private:
     FocusFireFSMState* m_nextState;
     const sc2::Unit * m_unit;
-    const sc2::Unit * m_target;
 
 public:
-    ShouldPullBackTransition(const sc2::Unit * unit, const sc2::Unit * target, FocusFireFSMState* nextState);
-    bool isValid(const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*);
+    ShouldPullBackTransition(const sc2::Unit * unit, FocusFireFSMState* nextState);
+    bool isValid(const sc2::Unit * target, const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*);
     FocusFireFSMState* getNextState();
     void onTransition();
 };

--- a/src/ShouldPullBackTransition.h
+++ b/src/ShouldPullBackTransition.h
@@ -11,7 +11,7 @@ private:
 
 public:
     ShouldPullBackTransition(const sc2::Unit * unit, const sc2::Unit * target, FocusFireFSMState* nextState);
-    bool isValid(std::unordered_map<sc2::Tag, float> *, CCBot*);
+    bool isValid(const std::vector<const sc2::Unit*> * units, std::unordered_map<sc2::Tag, float> *, CCBot*);
     FocusFireFSMState* getNextState();
     void onTransition();
 };

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -225,6 +225,18 @@ float Util::GetAttackRangeForTarget(const sc2::Unit * unit, const sc2::Unit * ta
 	return maxRange;
 }
 
+float Util::GetMaxAttackRangeForTargets(const sc2::Unit * unit, const std::vector<const sc2::Unit *> & targets, CCBot & bot)
+{
+    float maxRange = 0.f;
+    for (const sc2::Unit * target : targets)
+    {
+        float range = GetAttackRangeForTarget(unit, target, bot);
+        if (range > maxRange)
+            maxRange = range;
+    }
+    return maxRange;
+}
+
 bool Util::IsDetectorType(const sc2::UnitTypeID & type)
 {
     switch (type.ToType())

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -171,6 +171,18 @@ sc2::Point2D Util::CalcCenter(const std::vector<const sc2::Unit *> & units)
     return sc2::Point2D(cx / units.size(), cy / units.size());
 }
 
+void Util::Normalize(sc2::Point2D& point)
+{
+    float norm = sqrt(pow(point.x, 2) + pow(point.y, 2));
+    point /= norm;
+}
+
+sc2::Point2D Util::Normalized(const sc2::Point2D& point)
+{
+    float norm = sqrt(pow(point.x, 2) + pow(point.y, 2));
+    return sc2::Point2D(point.x / norm, point.y / norm);
+}
+
 bool Util::IsDetector(const sc2::Unit * unit)
 {
     BOT_ASSERT(unit, "Unit pointer was null");
@@ -298,6 +310,32 @@ float Util::DistSq(const sc2::Point2D & p1, const sc2::Point2D & p2)
     float dy = p1.y - p2.y;
 
     return dx*dx + dy*dy;
+}
+
+sc2::Point2D Util::CalcLinearRegression(const std::vector<const sc2::Unit *> & units)
+{
+    float sumX = 0, sumY = 0, sumXSqr = 0, sumXY = 0, avgX, avgY, numerator, denominator, slope;
+    int size = units.size();
+    for (auto unit : units)
+    {
+        sumX += unit->pos.x;
+        sumY += unit->pos.y;
+        sumXSqr += pow(unit->pos.x, 2);
+        sumXY += unit->pos.x * unit->pos.y;
+    }
+    avgX = sumX / size;
+    avgY = sumY / size;
+    denominator = size * sumXSqr - pow(sumX, 2);
+    if (denominator == 0.f)
+        return sc2::Point2D(0, 1);
+    numerator = size * sumXY - sumX * sumY;
+    slope = numerator / denominator;
+    return Util::Normalized(sc2::Point2D(1, slope));
+}
+
+sc2::Point2D Util::CalcPerpendicularVector(const sc2::Point2D & vector)
+{
+    return sc2::Point2D(vector.y, -vector.x);
 }
 
 bool Util::Pathable(const sc2::GameInfo & info, const sc2::Point2D & point) 

--- a/src/Util.h
+++ b/src/Util.h
@@ -45,6 +45,8 @@ namespace Util
     std::string     GetStringFromRace(const sc2::Race & race);
     sc2::Race       GetRaceFromString(const std::string & race);
     sc2::Point2D    CalcCenter(const std::vector<const sc2::Unit *> & units);
+    void            Normalize(sc2::Point2D& point);
+    sc2::Point2D    Normalized(const sc2::Point2D& point);
     sc2::UnitTypeData GetUnitTypeDataFromUnitTypeId(const sc2::UnitTypeID unitTypeId, CCBot & bot);
 
     sc2::UnitTypeID GetUnitTypeIDFromName(const std::string & name, CCBot & bot);
@@ -54,6 +56,9 @@ namespace Util
 
     float Dist(const sc2::Point2D & p1, const sc2::Point2D & p2);
     float DistSq(const sc2::Point2D & p1, const sc2::Point2D & p2);
+
+    sc2::Point2D CalcLinearRegression(const std::vector<const sc2::Unit *> & units);
+    sc2::Point2D CalcPerpendicularVector(const sc2::Point2D & vector);
     
     // Kevin-provided helper functions
     void    VisualizeGrids(const sc2::ObservationInterface* obs, sc2::DebugInterface* debug);

--- a/src/Util.h
+++ b/src/Util.h
@@ -34,6 +34,7 @@ namespace Util
     bool IsCompleted(const sc2::Unit * unit);
     float GetAttackRange(const sc2::UnitTypeID & type, CCBot & bot);
     float GetAttackRangeForTarget(const sc2::Unit * unit, const sc2::Unit * target, CCBot & bot);
+    float GetMaxAttackRangeForTargets(const sc2::Unit * unit, const std::vector<const sc2::Unit *> & targets, CCBot & bot);
     
     bool UnitCanBuildTypeNow(const sc2::Unit * unit, const sc2::UnitTypeID & type, CCBot & m_bot);
     int GetUnitTypeWidth(const sc2::UnitTypeID type, const CCBot & bot);

--- a/src/Util.h
+++ b/src/Util.h
@@ -35,6 +35,7 @@ namespace Util
     float GetAttackRange(const sc2::UnitTypeID & type, CCBot & bot);
     float GetAttackRangeForTarget(const sc2::Unit * unit, const sc2::Unit * target, CCBot & bot);
     float GetMaxAttackRangeForTargets(const sc2::Unit * unit, const std::vector<const sc2::Unit *> & targets, CCBot & bot);
+    float GetAttackDamageForTarget(const sc2::Unit * unit, const sc2::Unit * target, CCBot & bot);
     
     bool UnitCanBuildTypeNow(const sc2::Unit * unit, const sc2::UnitTypeID & type, CCBot & m_bot);
     int GetUnitTypeWidth(const sc2::UnitTypeID type, const CCBot & bot);


### PR DESCRIPTION
J'ai laissé faire la partie de l'angle d'attaque parce que c'était inutilisable en situation de match.
La plupart des changements sont donc liés au behavior de FocusFire.
Avec mes changements, on gagne dans DefeatRoaches environ 50% du temps, ce qui est similaire au trained agent de DeepMind.

J'ai identifié des faiblesses de notre behavior qui sont trop difficile à régler pour valoir la peine.
1. nos units essaient de backer même s'il n'y a pas de place en arrière d'eux
2. aucune prise en compte des enemy units autre que la target :
	a. nos units qui se font attaquer par ces enemy units reviennent dans leur range après avoir backé
	b. notre unit est parfois la cible d'assez d'enemy units pour se faire oneshot