### PR TITLE
Evaluate player death in the eval method.

### DIFF
--- a/bin/GameBotConfig.txt
+++ b/bin/GameBotConfig.txt
@@ -1,0 +1,145 @@
+{
+    "Bot Info" :
+    {
+        "BotName"                   : "CommandCenter",
+        "Authors"                   : "David Churchill",
+        "PrintInfoOnStart"          : false
+    },
+
+    "BWAPI" : 
+    {
+        "SetLocalSpeed"             : 5,
+        "SetFrameSkip"              : 0,
+        "UserInput"                 : true,
+        "CompleteMapInformation"    : false
+    },
+    
+    "SC2API" :
+    {
+        "BotRace"                   : "Terran",
+        "EnemyDifficulty"           : 10,
+        "EnemyRace"                 : "Zerg",
+        "MapFile"                   : "AbyssalReefLE.SC2Map",
+        "StepSize"                  : 1
+    },
+        
+    "Micro" :
+    {
+		"AlphaBetaPruning"			: true,
+        "KiteWithRangedUnits"       : true,
+        "ScoutHarassEnemy"          : true
+    },
+    
+    "Macro" :
+    {
+        "WorkersPerRefinery"        : 3,
+        "BuildingSpacing"           : 0,
+        "PylonSpacing"              : 3
+    },
+
+    "Debug" :
+    {
+        "DrawGameInfo"              : true, 
+        "DrawProductionInfo"        : true, 
+        "DrawBaseLocationInfo"      : true,
+        "DrawTileInfo"              : false,
+        "DrawWalkableSectors"       : false,
+        "DrawScoutInfo"             : false,
+        "DrawEnemyUnitInfo"         : false,
+        "DrawResourceInfo"          : false,
+        "DrawUnitTargetInfo"        : true,
+        "DrawLastSeenTileInfo"      : false,
+        "DrawSquadInfo"             : false,
+        "DrawWorkerInfo"            : false,
+        "DrawBuildingInfo"          : false,
+        "DrawReservedBuildingTiles" : false
+    },
+    
+    "Modules" :
+    {
+        "UseAutoObserver"           : false
+    },
+    
+    "BWAPI Strategy" :
+    {
+        "Protoss"                   : "Protoss_ZealotRush",
+        "Terran"                    : "Terran_MarineRush",
+        "Zerg"                      : "Zerg_ZerglingRush",
+        
+        "ScoutHarassEnemy"          : true,
+        
+        "Strategies" :
+        {
+            "Protoss_ZealotRush"    : 
+            { 
+                "Race"              : "Protoss", 
+                "OpeningBuildOrder" : ["Probe", "Probe", "Probe", "Probe", "Pylon", "Probe", "Gateway", "Gateway", "Probe", "Probe", "Zealot", "Pylon", "Zealot", "Zealot",  "Probe", "Zealot", "Zealot", "Probe", "Pylon", "Zealot", "Gateway", "Probe", "Pylon", "Probe", "Zealot", "Probe", "Zealot", "Zealot", "Zealot", "Zealot", "Pylon", "Probe", "Zealot", "Zealot", "Zealot" ],
+                "ScoutCondition"    : [ ["Self", "Pylon"], ">", [ 0 ] ],
+                "AttackCondition"   : [ ["Self", "Zealot"], ">=", [ 3 ] ]
+            },
+            "Protoss_DragoonRush"   : 
+            { 
+                "Race"              : "Protoss", 
+                "OpeningBuildOrder" : ["Probe", "Probe", "Probe", "Probe", "Pylon", "Probe", "Probe", "Gateway", "Probe", "Assimilator", "Probe", "Probe", "Cybernetics_Core", "Probe", "Probe", "Gateway", "Singularity_Charge", "Dragoon", "Gateway", "Pylon", "Dragoon", "Dragoon", "Probe", "Gateway", "Pylon", "Probe", "Dragoon", "Dragoon", "Dragoon"],
+                "ScoutCondition"    : [ ["Self", "Pylon"], ">", [ 0 ] ],
+                "AttackCondition"   : [ ["Self", "Dragoon"], ">=", [ 3 ] ]
+            },
+            "Terran_MarineRush"     : 
+            { 
+                "Race"              : "Terran",  
+                "OpeningBuildOrder" : ["SCV", "SCV", "SCV", "SCV", "Barracks", "Barracks", "SCV", "Supply Depot", "SCV", "Marine", "Marine", "Marine", "Marine", "Supply Depot"], 
+                "ScoutCondition"    : [ ["Self", "Supply Depot"], ">", [ 0 ] ],
+                "AttackCondition"   : [ ["Self", "Marine"], ">=", [ 4 ] ]
+            },
+            "Zerg_ZerglingRush"     : 
+            { 
+                "Race"              : "Zerg",    
+                "OpeningBuildOrder" : ["Drone", "Spawning Pool", "Zergling", "Zergling", "Zergling", "Zergling"],
+                "ScoutCondition"    : [ ["Self", "Spawning Pool"], ">", [ 0 ] ],
+                "AttackCondition"   : [ ["Self", "Zergling"], ">=", [ 0 ] ]
+            }
+        }
+    },
+    
+    "SC2API Strategy" :
+    {
+        "Protoss"                   : "Protoss_ZealotRush",
+        "Terran"                    : "Terran_MarineRush",
+        "Zerg"                      : "Zerg_2HatchRoach",
+        
+        "ScoutHarassEnemy"          : true,
+        "AutoCompleteBuildOrder"	: true,
+        
+        "Strategies" :
+        {
+            "Protoss_ZealotRush"    : 
+            { 
+                "Race"              : "Protoss", 
+                "OpeningBuildOrder" : ["Probe", "Probe", "Pylon", "Probe", "Probe", "Gateway", "Pylon", "Probe", "Gateway", "Probe", "Gateway", "Pylon", "Probe", "Zealot", "Zealot", "Pylon", "Zealot", "Zealot", "Pylon", "Zealot", "Zealot", "Zealot", "Zealot", "Zealot", "Zealot", "Zealot", "Zealot", "Zealot", "Zealot"],
+                "ScoutCondition"    : [ ["Self", "Pylon"], ">", [ 0 ] ],
+                "AttackCondition"   : [ ["Self", "Zealot"], ">=", [ 8 ] ]
+            },
+            "Terran_MarineRush"     : 
+            { 
+                "Race"              : "Terran",  
+                "OpeningBuildOrder" : ["SCV", "SCV", "SupplyDepot", "SCV", "SCV", "Barracks", "Barracks", "Barracks", "Barracks", "SupplyDepot", "SupplyDepot", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine", "Marine"],
+                "ScoutCondition"    : [ ["Self", "SupplyDepot"], ">", [ 0 ] ],
+                "AttackCondition"   : [ ["Self", "Marine"], ">=", [ 8 ] ]
+            },
+            "Zerg_ZerglingRush"     : 
+            { 
+                "Race"              : "Zerg",    
+                "OpeningBuildOrder" : ["SpawningPool", "Drone", "Overlord", "Drone", "Zergling", "Zergling", "Zergling", "Zergling", "Zergling", "Zergling", "Zergling", "Zergling"], 
+                "ScoutCondition"    : [ ["GameFrame"], ">=", [ 100 ] ],
+                "AttackCondition"   : [ ["Self", "Zergling"], ">", [ 0 ] ]    
+            },
+            "Zerg_2HatchRoach"      : 
+            { 
+                "Race"              : "Zerg",    
+                "OpeningBuildOrder" : ["SpawningPool", "Drone", "Overlord", "Drone", "Drone", "Extractor", "Drone", "Drone", "Hatchery", "Drone", "Overlord", "Drone", "RoachWarren", "Drone", "Drone", "Drone", "Drone", "Roach", "Overlord", "Roach", "Roach", "Roach", "Roach", "Overlord", "Roach", "Roach", "Roach", "Roach", "Roach", "Roach", "Roach"],
+                "ScoutCondition"    : [ ["self", "SpawningPool"], ">=", [ 1 ] ],
+                "AttackCondition"   : [ [["Self", "Roach"], ">=", [ 12 ]], "AND", [["Self", "Overlord"], ">=", [ 1 ]] ]    
+            }
+        }
+    }
+}

--- a/src/AlphaBetaState.cpp
+++ b/src/AlphaBetaState.cpp
@@ -19,7 +19,7 @@ void AlphaBetaState::doMove(AlphaBetaMove * move) {
     for (auto action : move->actions) {
         if (action->type == AlphaBetaActionType::ATTACK) {
             // do attack
-            action->target->hp_current -= action->unit->damage;
+            action->target->InflictDamage(action->unit->damage);
             action->unit->attack_time = action->time;
         }
         else if (action->type == AlphaBetaActionType::MOVE_BACK || action->type == AlphaBetaActionType::MOVE_FORWARD) {
@@ -214,11 +214,22 @@ bool AlphaBetaState::unitShouldMoveBack(AlphaBetaUnit * unit, std::vector<std::s
 AlphaBetaValue AlphaBetaState::eval() {
     float totalPlayerDamage = 0;
     float totalEnemyDamage = 0;
+	// We check if at least one unit is still alive. If no unit is alive, we add a huge value.
+	bool oneMinIsAlive = false;
+	bool oneMaxIsAlive = false;
     for (auto unit : playerMin.units) {
+		oneMinIsAlive |= !unit->is_dead;
         totalEnemyDamage += (unit->hp_max - unit->hp_current);
     }
+	if (!oneMinIsAlive)
+		totalEnemyDamage += 100000;
+
     for (auto unit : playerMax.units) {
+		oneMaxIsAlive |= !unit->is_dead;
         totalPlayerDamage += (unit->hp_max - unit->hp_current);
     }
+	if (!oneMaxIsAlive)
+		totalPlayerDamage += 100000;
+
     return AlphaBetaValue(totalEnemyDamage - totalPlayerDamage, nullptr, this);
 }

--- a/src/AlphaBetaUnit.cpp
+++ b/src/AlphaBetaUnit.cpp
@@ -29,6 +29,7 @@ AlphaBetaUnit::AlphaBetaUnit(const sc2::Unit * actual_unit, CCBot * bot) {
     previous_action = nullptr;
     attack_time = actual_unit->weapon_cooldown;
     move_time = 0.f;
+	UpdateIsDead();
 }
 
 AlphaBetaUnit::AlphaBetaUnit(const sc2::Unit * pactual_unit, float php_current, float php_max, float pdamage, float prange, float pcooldown_max, float pspeed, float pattack_time, float pmove_time, sc2::Point2D pposition, AlphaBetaAction * pprevious_action) {
@@ -43,4 +44,15 @@ AlphaBetaUnit::AlphaBetaUnit(const sc2::Unit * pactual_unit, float php_current, 
     previous_action = pprevious_action;
     attack_time = pattack_time;
     move_time = pmove_time;
-};
+	UpdateIsDead();
+}
+void AlphaBetaUnit::InflictDamage(float damage)
+{
+	hp_current -= damage;
+	UpdateIsDead();
+}
+void AlphaBetaUnit::UpdateIsDead()
+{
+	is_dead = hp_current <= 0.f;
+}
+;

--- a/src/AlphaBetaUnit.h
+++ b/src/AlphaBetaUnit.h
@@ -19,6 +19,7 @@ public:
     float attack_time; // time unit completed attack
     float move_time; // time unit last completed movement
     float speed;
+	bool is_dead;
     sc2::Point2D position;
     AlphaBetaAction * previous_action;
 
@@ -26,6 +27,10 @@ public:
     AlphaBetaUnit();
     AlphaBetaUnit(const sc2::Unit * actual_unit, CCBot * bot);
     AlphaBetaUnit(const sc2::Unit * pactual_unit, float php_current, float php_max, float pdamage, float prange, float pcooldown_max, float pspeed, float pattack_time, float pmove_time, sc2::Point2D pposition, AlphaBetaAction * pprevious_action);
+
+	void InflictDamage(float damage);
+private:
+	void UpdateIsDead();
 };
 
 #endif 


### PR DESCRIPTION
The eval method when the max depth is reached now take into account the death of a player.

I have tested 10 times with this change and 10 times without the change. (Scores at the end of the mini-game zergling and banelings)
With this change: average: 823
Without: average: 847
We should discuss if we want to use this or not base on these results.

List of values: 

With player death
--
768
846
891
804
847
813
808
847
847
747
841


without player death
--
843
857
847
845
849
794
900
898
794
802
896


