### PR TITLE
Fix illegal call with temporary variable

### DIFF
--- a/src/UCTConsideringDurations.cpp
+++ b/src/UCTConsideringDurations.cpp
@@ -27,7 +27,8 @@ UCTCDMove UCTConsideringDurations::UCTCD(UCTCDState state)
     UCTCDNode root = UCTCDNode();
     root.type = UCTCDNodeType::ROOT;
     for (traversals; traversals < max_traversals; ++traversals) {
-        traverse(root, UCTCDState(state));
+        UCTCDState copyState = UCTCDState(state);
+        traverse(root, copyState);
         auto end = std::chrono::high_resolution_clock::now();
         time_spent = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
         if (time_spent.count() > time_limit)


### PR DESCRIPTION
For more information:
https://stackoverflow.com/questions/1565600/how-come-a-non-const-reference-cannot-bind-to-a-temporary-object

VS allow this with warning but for gcc its an error